### PR TITLE
Fix Sequence import for Python 3.11

### DIFF
--- a/data/image_transforms.py
+++ b/data/image_transforms.py
@@ -4,7 +4,7 @@ Image transforms functions for data augmentation
 Credit to Dr. Jo Schlemper
 """
 
-from collections import Sequence
+from collections.abc import Sequence
 import cv2
 import numpy as np
 import scipy


### PR DESCRIPTION
## Summary
- update `data/image_transforms.py` to use `collections.abc.Sequence`

## Testing
- `python -m py_compile data/image_transforms.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jaraco.path')*

------
https://chatgpt.com/codex/tasks/task_e_68408f613790832aa984b64ccc71ac25